### PR TITLE
Fix OpenFaaS client authentication to use authentication from Terraform provider initialization

### DIFF
--- a/openfaas/resource_openfaas_function.go
+++ b/openfaas/resource_openfaas_function.go
@@ -168,9 +168,10 @@ func isFunctionNotFound(err error) bool {
 var whiteListLabels = map[string]string{
 	"labels.com.openfaas.function": "",
 	"labels.function":              "",
+	"labels.uid":                   "",
 }
 
-const extraProviderLabelsCount = 2
+const extraProviderLabelsCount = 3
 
 func labelsDiffFunc(k, old, new string, d *schema.ResourceData) bool {
 	if _, ok := whiteListLabels[k]; ok {

--- a/openfaas/structure.go
+++ b/openfaas/structure.go
@@ -11,6 +11,7 @@ func expandDeploymentSpec(d *schema.ResourceData, name string) *proxy.DeployFunc
 	deploySpec := &proxy.DeployFunctionSpec{
 		FunctionName: name,
 		Image:        d.Get("image").(string),
+		Update:       true,
 	}
 
 	if v, ok := d.GetOk("network"); ok {


### PR DESCRIPTION
Currently, this provider was accepting `user_name` and `password` in Terraform provider initialization, but there is no reference in the code that uses it to instantiate the OpenFaaS client.

This commit adds a credentials chain so it tries to get the authentication in the following order:

1. Authentication with basic-auth using username and password from Terraform provider initialization
2. Authentication with basic-auth using OpenFaaS config file created from `faas-cli login`
3. Authentication with token using OpenFaaS config file created from `faas-cli login`

Also, adds a few log messages to help understand which credential is choosen from the chain.

---

In addition, this pull-request also solves an issue with updating an existing function Deployment and whitelists the label `uid` so it does not trigger a diff, even if the Terraform is up-to-dated.